### PR TITLE
Allow only single click on data confirm button

### DIFF
--- a/vendor/assets/javascripts/data-confirm-modal.js
+++ b/vendor/assets/javascripts/data-confirm-modal.js
@@ -73,7 +73,7 @@
         modal.remove();
       });
 
-      modal.find('.commit').on('click', function () {
+      modal.find('.commit').one('click', function () {
         if (options.onConfirm && options.onConfirm.call)
           options.onConfirm.call();
 


### PR DESCRIPTION
Made use of JQuery one() method to make sure only one event is triggered on click of confirm button.

Reference - https://api.jquery.com/one/